### PR TITLE
Check responsive popup detail in Table Item between pages

### DIFF
--- a/public/locales/vi/common.json
+++ b/public/locales/vi/common.json
@@ -1400,7 +1400,8 @@
         "edit": "Cập nhật văn phòng phẩm",
         "date": "Thời gian",
         "checkout": "Cấp phát",
-        "detail": "Chi tiết văn phòng phẩm"
+        "detail": "Chi tiết văn phòng phẩm",
+        "maintenance": "Bảo trì văn phòng phẩm"
       },
       "tooltip": {
         "create": "Thêm mới",

--- a/src/pages/accessory/show.tsx
+++ b/src/pages/accessory/show.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from "@pankod/refine-core";
-import { Typography, Row, Col, MarkdownField } from "@pankod/refine-antd";
+import { Typography, Row, Col, MarkdownField, Grid } from "@pankod/refine-antd";
 
 import "styles/hardware.less";
 import { IAccesstoryResponse } from "interfaces/accessory";
@@ -14,22 +14,23 @@ type AccessoryShowProps = {
 export const AccessoryShow = (props: AccessoryShowProps) => {
   const { detail } = props;
   const translate = useTranslate();
-
+  const breakpoint = Grid.useBreakpoint();
+  const isMobile = !breakpoint.lg;
   return (
     <>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>{translate("accessory.label.field.name")}</Title>
         </Col>
-        <Col>
+        <Col span={14}>
           <Text>{detail && detail?.name}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>{translate("accessory.label.field.category")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.category ? (
             <Text className="show-asset">
               {detail?.category && detail?.category.name}
@@ -40,10 +41,10 @@ export const AccessoryShow = (props: AccessoryShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>{translate("accessory.label.field.location")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.location ? (
             <Text className="show-asset">
               {detail?.location && detail?.location.name}
@@ -54,12 +55,12 @@ export const AccessoryShow = (props: AccessoryShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("accessory.label.field.manufacturer")}
           </Title>
         </Col>
-        <Col>
+        <Col span={14}>
           {detail?.manufacturer ? (
             <>
               <Text className="show-asset">
@@ -72,10 +73,10 @@ export const AccessoryShow = (props: AccessoryShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>{translate("accessory.label.field.supplier")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.supplier ? (
             <>
               <div
@@ -90,34 +91,34 @@ export const AccessoryShow = (props: AccessoryShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("accessory.label.field.purchase_cost")}
           </Title>
         </Col>
-        <Col>
+        <Col span={14}>
           <Text>{detail?.purchase_cost && detail?.purchase_cost}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("accessory.label.field.purchase_date")}
           </Title>
         </Col>
-        <Col>
+        <Col span={14}>
           <Text>
             {detail?.purchase_date && detail?.purchase_date.formatted}
           </Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("accessory.label.field.insurance")}
           </Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>
             {detail?.warranty_months}
             {" months"}
@@ -125,10 +126,10 @@ export const AccessoryShow = (props: AccessoryShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>{translate("accessory.label.field.notes")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <div
             dangerouslySetInnerHTML={{
               __html: `${detail?.notes ? detail?.notes : ""}`,
@@ -137,12 +138,12 @@ export const AccessoryShow = (props: AccessoryShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("accessory.label.field.created_at")}
           </Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.created_at ? (
             <Text>
               {" "}
@@ -157,12 +158,12 @@ export const AccessoryShow = (props: AccessoryShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("accessory.label.field.updated_at")}
           </Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>
             {" "}
             {detail?.updated_at &&
@@ -173,20 +174,20 @@ export const AccessoryShow = (props: AccessoryShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>{translate("accessory.label.field.qty")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail?.qty && detail?.qty}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("accessory.label.field.remaining_qty")}
           </Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail?.remaining_qty && detail?.remaining_qty}</Text>
         </Col>
       </Row>

--- a/src/pages/consumables/list-maintenance.tsx
+++ b/src/pages/consumables/list-maintenance.tsx
@@ -416,7 +416,11 @@ export const ConsumablesMainternanceList: React.FC<
 
   return (
     <List
-      title={translate("consumables.label.title.consumables")}
+      title={
+        <div style={{ whiteSpace: "normal", wordBreak: "break-word" }}>
+          {translate("consumables.label.title.maintenance")}
+        </div>
+      }
       pageHeaderProps={{
         extra: permissionsData.admin === EPermissions.ADMIN && (
           <CreateButton onClick={handleCreate}>

--- a/src/pages/consumables/show.tsx
+++ b/src/pages/consumables/show.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from "@pankod/refine-core";
-import { Typography, Row, Col, MarkdownField } from "@pankod/refine-antd";
+import { Typography, Row, Col, MarkdownField, Grid } from "@pankod/refine-antd";
 
 import "styles/hardware.less";
 import { IConsumablesResponse } from "interfaces/consumables";
@@ -14,24 +14,26 @@ type ConsumablesShowProps = {
 export const ConsumablesShow = (props: ConsumablesShowProps) => {
   const { detail } = props;
   const translate = useTranslate();
+  const breakpoint = Grid.useBreakpoint();
+  const isMobile = !breakpoint.lg;
 
   return (
     <>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>{translate("consumables.label.field.name")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail && detail?.name}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("consumables.label.field.category")}
           </Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.category ? (
             <Text className="show-asset">
               {detail?.category && detail?.category.name}
@@ -42,12 +44,12 @@ export const ConsumablesShow = (props: ConsumablesShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("consumables.label.field.location")}
           </Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.location ? (
             <Text className="show-asset">
               {detail?.location && detail?.location.name}
@@ -58,12 +60,12 @@ export const ConsumablesShow = (props: ConsumablesShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("consumables.label.field.manufacturer")}
           </Title>
         </Col>
-        <Col>
+        <Col span={14}>
           {detail?.manufacturer ? (
             <>
               <Text className="show-asset">
@@ -76,12 +78,12 @@ export const ConsumablesShow = (props: ConsumablesShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("consumables.label.field.supplier")}
           </Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.supplier ? (
             <>
               <div
@@ -96,34 +98,34 @@ export const ConsumablesShow = (props: ConsumablesShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("consumables.label.field.purchase_cost")}
           </Title>
         </Col>
-        <Col>
+        <Col span={14}>
           <Text>{detail?.purchase_cost && detail?.purchase_cost}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("consumables.label.field.purchase_date")}
           </Title>
         </Col>
-        <Col>
+        <Col span={14}>
           <Text>
             {detail?.purchase_date && detail?.purchase_date.formatted}
           </Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("consumables.label.field.insurance")}
           </Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>
             {detail?.warranty_months}
             {" months"}
@@ -131,10 +133,10 @@ export const ConsumablesShow = (props: ConsumablesShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>{translate("consumables.label.field.notes")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <div
             dangerouslySetInnerHTML={{
               __html: `${detail?.notes ? detail?.notes : ""}`,
@@ -143,12 +145,12 @@ export const ConsumablesShow = (props: ConsumablesShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("consumables.label.field.created_at")}
           </Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.created_at ? (
             <Text>
               {" "}
@@ -163,12 +165,12 @@ export const ConsumablesShow = (props: ConsumablesShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("consumables.label.field.updated_at")}
           </Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>
             {" "}
             {detail?.updated_at &&
@@ -179,30 +181,30 @@ export const ConsumablesShow = (props: ConsumablesShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>{translate("consumables.label.field.qty")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail?.qty && detail?.qty}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={6}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("consumables.label.field.remaining")}
           </Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail?.remaining && detail?.remaining}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("consumables.label.field.maintenance_date")}
           </Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>
             {" "}
             {detail?.maintenance_date &&
@@ -213,12 +215,12 @@ export const ConsumablesShow = (props: ConsumablesShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 6}>
           <Title level={5}>
             {translate("consumables.label.field.maintenance_cycle")}
           </Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.maintenance_cycle ? (
             <>
               <Text>

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -121,6 +121,10 @@ export const DashboardPage: React.FC<IResourceComponentsProps> = () => {
       )} đến ${searchParams1.get("purchase_date_to")}`
     );
   };
+  const locationName = data?.data.payload.find(
+    (item: ILocation) => item.id === locationSelected
+  )?.name;
+  console.log("locationName", locationName);
 
   useEffect(() => {
     localStorage.removeItem("purchase_date");
@@ -183,7 +187,7 @@ export const DashboardPage: React.FC<IResourceComponentsProps> = () => {
               <Form.Item
                 label={translate("dashboard.field.search-location")}
                 name="location"
-                initialValue={99999}
+                initialValue={locationName}
               >
                 <Select
                   allowClear

--- a/src/pages/dashboard/list_checkin_checkout.tsx
+++ b/src/pages/dashboard/list_checkin_checkout.tsx
@@ -544,7 +544,13 @@ export const ListCheckin_Checkout: React.FC<IResourceComponentsProps> = () => {
 
   return (
     <>
-      <List title={translate("dashboard.titleStatistic")}>
+      <List
+        title={
+          <div style={{ whiteSpace: "normal", wordBreak: "break-word" }}>
+            {translate("dashboard.titleStatistic")}
+          </div>
+        }
+      >
         <section className="reportAssetContainer">
           <span className="title-section-dashboard">
             {translate("report.label.title.nameReportCheckOut")}

--- a/src/pages/hardware/list-broken.tsx
+++ b/src/pages/hardware/list-broken.tsx
@@ -934,7 +934,11 @@ export const HardwareListBroken: React.FC<IResourceComponentsProps> = () => {
 
   return (
     <List
-      title={t("hardware.label.title.list-broken")}
+      title={
+        <div style={{ whiteSpace: "normal", wordBreak: "break-word" }}>
+          {t("hardware.label.title.list-broken")}
+        </div>
+      }
       pageHeaderProps={{
         extra: permissionsData.admin === EPermissions.ADMIN && (
           <CreateButton onClick={handleCreate}>

--- a/src/pages/hardware/list-readyToDeploy.tsx
+++ b/src/pages/hardware/list-readyToDeploy.tsx
@@ -1140,7 +1140,11 @@ export const HardwareListReadyToDeploy: React.FC<
 
   return (
     <List
-      title={t("hardware.label.title.list-readyToDeploy")}
+      title={
+        <div style={{ whiteSpace: "normal", wordBreak: "break-word" }}>
+          {t("hardware.label.title.list-readyToDeploy")}
+        </div>
+      }
       pageHeaderProps={{
         extra: isAdmin && (
           <CreateButton onClick={handleCreate}>

--- a/src/pages/hardware/show.tsx
+++ b/src/pages/hardware/show.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from "@pankod/refine-core";
-import { Typography, Tag, Row, Col } from "@pankod/refine-antd";
+import { Typography, Tag, Row, Col, Grid } from "@pankod/refine-antd";
 import { UserOutlined } from "@ant-design/icons";
 import { IHardwareResponse } from "interfaces/hardware";
 import "styles/hardware.less";
@@ -15,13 +15,16 @@ type HardwareShowProps = {
 export const HardwareShow = (props: HardwareShowProps) => {
   const { detail } = props;
   const t = useTranslate();
+  const breakpoint = Grid.useBreakpoint();
+  const isMobile = !breakpoint.lg;
+
   return (
     <>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.field.status")}</Title>
         </Col>
-        <Col>
+        <Col span={14}>
           <Text>
             <Tag>{getDetailAssetStatus(detail)}</Tag>
             {detail?.assigned_to ? (
@@ -38,26 +41,26 @@ export const HardwareShow = (props: HardwareShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.field.assetName")}</Title>
         </Col>
-        <Col>
+        <Col span={14}>
           <Text>{detail && detail?.name}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.field.serial")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail && detail?.serial}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.field.manufacturer")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text className="show-asset">
             {detail?.manufacturer ? (
               <>
@@ -72,38 +75,38 @@ export const HardwareShow = (props: HardwareShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.field.category")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text className="show-asset">{detail && detail?.category.name}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.field.propertyType")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text className="show-asset">
             {detail?.model && detail?.model.name}
           </Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.field.purchase_date")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>
             {detail?.purchase_date && detail?.purchase_date.formatted}
           </Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.field.supplier")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.supplier ? (
             <>
               <div
@@ -119,10 +122,10 @@ export const HardwareShow = (props: HardwareShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.field.insurance")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>
             {detail?.warranty_months} (
             {t("hardware.label.field.warranty_expires")}{" "}
@@ -131,10 +134,10 @@ export const HardwareShow = (props: HardwareShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.field.notes")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <div
             dangerouslySetInnerHTML={{
               __html: `<span>${detail?.notes ? detail?.notes : ""}</span>`,
@@ -143,10 +146,10 @@ export const HardwareShow = (props: HardwareShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.field.rtd_location")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.rtd_location ? (
             <Text className="show-asset">
               {detail?.rtd_location && detail?.rtd_location.name}
@@ -157,10 +160,10 @@ export const HardwareShow = (props: HardwareShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.title.dateCreate")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.created_at ? (
             <Text>
               {" "}
@@ -175,10 +178,10 @@ export const HardwareShow = (props: HardwareShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.title.updateAt")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>
             {" "}
             {detail?.updated_at &&
@@ -189,10 +192,10 @@ export const HardwareShow = (props: HardwareShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.field.dateCheckout")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.last_checkout ? (
             <>
               <Text>
@@ -205,42 +208,42 @@ export const HardwareShow = (props: HardwareShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.field.checkin_counter")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail && detail?.checkin_counter}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.field.checkout_counter")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail && detail?.checkout_counter}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.field.requestable")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail && detail?.requests_counter}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.field.purchase_cost")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail?.purchase_cost && detail?.purchase_cost}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.field.maintenance_date")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>
             {" "}
             {detail?.maintenance_date &&
@@ -251,10 +254,10 @@ export const HardwareShow = (props: HardwareShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("hardware.label.field.maintenance_cycle")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.maintenance_cycle ? (
             <>
               <Text>

--- a/src/pages/hardware_client/list-broken.tsx
+++ b/src/pages/hardware_client/list-broken.tsx
@@ -932,7 +932,11 @@ export const ClientHardwareListBroken: React.FC<
 
   return (
     <List
-      title={t("hardware.label.title.list-broken")}
+      title={
+        <div style={{ whiteSpace: "normal", wordBreak: "break-word" }}>
+          {t("hardware.label.title.list-broken")}
+        </div>
+      }
       pageHeaderProps={{
         extra: permissionsData.admin === EPermissions.ADMIN && (
           <CreateButton onClick={handleCreate}>

--- a/src/pages/hardware_client/list-readyToDeploy.tsx
+++ b/src/pages/hardware_client/list-readyToDeploy.tsx
@@ -1134,7 +1134,11 @@ export const ClientHardwareListReadyToDeploy: React.FC<
 
   return (
     <List
-      title={t("hardware.label.title.list-readyToDeploy")}
+      title={
+        <div style={{ whiteSpace: "normal", wordBreak: "break-word" }}>
+          {t("hardware.label.title.list-readyToDeploy")}
+        </div>
+      }
       pageHeaderProps={{
         extra: isAdmin && (
           <CreateButton onClick={handleCreate}>

--- a/src/pages/hardware_client/show.tsx
+++ b/src/pages/hardware_client/show.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from "@pankod/refine-core";
-import { Typography, Tag, Row, Col } from "@pankod/refine-antd";
+import { Typography, Tag, Row, Col, Grid } from "@pankod/refine-antd";
 import { UserOutlined } from "@ant-design/icons";
 import { IHardwareResponse } from "interfaces/hardware";
 import "styles/hardware.less";
@@ -15,16 +15,18 @@ type HardwareShowProps = {
 export const ClientHardwareShow = (props: HardwareShowProps) => {
   const { detail } = props;
   const t = useTranslate();
+  const breakpoint = Grid.useBreakpoint();
+  const isMobile = !breakpoint.lg;
 
   return (
     <div className="hardware-detail">
       <div className="hardware-information">
         <>
           <Row gutter={16}>
-            <Col className="gutter-row" span={4}>
+            <Col className="gutter-row" span={isMobile ? 10 : 4}>
               <Title level={5}>{t("hardware.label.field.status")}</Title>
             </Col>
-            <Col>
+            <Col span={14}>
               <Text>
                 <Tag>{getDetailAssetStatus(detail)}</Tag>
                 {detail?.assigned_to ? (
@@ -41,26 +43,26 @@ export const ClientHardwareShow = (props: HardwareShowProps) => {
             </Col>
           </Row>
           <Row gutter={16}>
-            <Col className="gutter-row" span={4}>
+            <Col className="gutter-row" span={isMobile ? 10 : 4}>
               <Title level={5}>{t("hardware.label.field.assetName")}</Title>
             </Col>
-            <Col>
+            <Col span={14}>
               <Text>{detail && detail?.name}</Text>
             </Col>
           </Row>
           <Row gutter={16}>
-            <Col className="gutter-row" span={4}>
+            <Col className="gutter-row" span={isMobile ? 10 : 4}>
               <Title level={5}>{t("hardware.label.field.serial")}</Title>
             </Col>
-            <Col span={18}>
+            <Col span={14}>
               <Text>{detail && detail?.serial}</Text>
             </Col>
           </Row>
           <Row gutter={16}>
-            <Col className="gutter-row" span={4}>
+            <Col className="gutter-row" span={isMobile ? 10 : 4}>
               <Title level={5}>{t("hardware.label.field.manufacturer")}</Title>
             </Col>
-            <Col span={18}>
+            <Col span={14}>
               <Text className="show-asset">
                 {detail?.manufacturer ? (
                   <>
@@ -75,40 +77,40 @@ export const ClientHardwareShow = (props: HardwareShowProps) => {
             </Col>
           </Row>
           <Row gutter={16}>
-            <Col className="gutter-row" span={4}>
+            <Col className="gutter-row" span={isMobile ? 10 : 4}>
               <Title level={5}>{t("hardware.label.field.category")}</Title>
             </Col>
-            <Col span={18}>
+            <Col span={14}>
               <Text className="show-asset">
                 {detail && detail?.category.name}
               </Text>
             </Col>
           </Row>
           <Row gutter={16}>
-            <Col className="gutter-row" span={4}>
+            <Col className="gutter-row" span={isMobile ? 10 : 4}>
               <Title level={5}>{t("hardware.label.field.propertyType")}</Title>
             </Col>
-            <Col span={18}>
+            <Col span={14}>
               <Text className="show-asset">
                 {detail?.model && detail?.model.name}
               </Text>
             </Col>
           </Row>
           <Row gutter={16}>
-            <Col className="gutter-row" span={4}>
+            <Col className="gutter-row" span={isMobile ? 10 : 4}>
               <Title level={5}>{t("hardware.label.field.purchase_date")}</Title>
             </Col>
-            <Col span={18}>
+            <Col span={14}>
               <Text>
                 {detail?.purchase_date && detail?.purchase_date.formatted}
               </Text>
             </Col>
           </Row>
           <Row gutter={16}>
-            <Col className="gutter-row" span={4}>
+            <Col className="gutter-row" span={isMobile ? 10 : 4}>
               <Title level={5}>{t("hardware.label.field.supplier")}</Title>
             </Col>
-            <Col span={18}>
+            <Col span={14}>
               {detail?.supplier ? (
                 <>
                   <div
@@ -124,10 +126,10 @@ export const ClientHardwareShow = (props: HardwareShowProps) => {
             </Col>
           </Row>
           <Row gutter={16}>
-            <Col className="gutter-row" span={4}>
+            <Col className="gutter-row" span={isMobile ? 10 : 4}>
               <Title level={5}>{t("hardware.label.field.insurance")}</Title>
             </Col>
-            <Col span={18}>
+            <Col span={14}>
               <Text>
                 {detail?.warranty_months} (
                 {t("hardware.label.field.warranty_expires")}{" "}
@@ -136,10 +138,10 @@ export const ClientHardwareShow = (props: HardwareShowProps) => {
             </Col>
           </Row>
           <Row gutter={16}>
-            <Col className="gutter-row" span={4}>
+            <Col className="gutter-row" span={isMobile ? 10 : 4}>
               <Title level={5}>{t("hardware.label.field.notes")}</Title>
             </Col>
-            <Col span={18}>
+            <Col span={14}>
               <div
                 dangerouslySetInnerHTML={{
                   __html: `<span>${detail?.notes ? detail?.notes : ""}</span>`,
@@ -148,10 +150,10 @@ export const ClientHardwareShow = (props: HardwareShowProps) => {
             </Col>
           </Row>
           <Row gutter={16}>
-            <Col className="gutter-row" span={4}>
+            <Col className="gutter-row" span={isMobile ? 10 : 4}>
               <Title level={5}>{t("hardware.label.field.rtd_location")}</Title>
             </Col>
-            <Col span={18}>
+            <Col span={14}>
               {detail?.rtd_location ? (
                 <Text className="show-asset">
                   {detail?.rtd_location && detail?.rtd_location.name}
@@ -162,10 +164,10 @@ export const ClientHardwareShow = (props: HardwareShowProps) => {
             </Col>
           </Row>
           <Row gutter={16}>
-            <Col className="gutter-row" span={4}>
+            <Col className="gutter-row" span={isMobile ? 10 : 4}>
               <Title level={5}>{t("hardware.label.title.dateCreate")}</Title>
             </Col>
-            <Col span={18}>
+            <Col span={14}>
               {detail?.created_at ? (
                 <Text>
                   {" "}
@@ -180,10 +182,10 @@ export const ClientHardwareShow = (props: HardwareShowProps) => {
             </Col>
           </Row>
           <Row gutter={16}>
-            <Col className="gutter-row" span={4}>
+            <Col className="gutter-row" span={isMobile ? 10 : 4}>
               <Title level={5}>{t("hardware.label.title.updateAt")}</Title>
             </Col>
-            <Col span={18}>
+            <Col span={14}>
               <Text>
                 {" "}
                 {detail?.updated_at &&
@@ -194,10 +196,10 @@ export const ClientHardwareShow = (props: HardwareShowProps) => {
             </Col>
           </Row>
           <Row gutter={16}>
-            <Col className="gutter-row" span={4}>
+            <Col className="gutter-row" span={isMobile ? 10 : 4}>
               <Title level={5}>{t("hardware.label.field.dateCheckout")}</Title>
             </Col>
-            <Col span={18}>
+            <Col span={14}>
               {detail?.last_checkout ? (
                 <>
                   <Text>
@@ -210,38 +212,38 @@ export const ClientHardwareShow = (props: HardwareShowProps) => {
             </Col>
           </Row>
           <Row gutter={16}>
-            <Col className="gutter-row" span={4}>
+            <Col className="gutter-row" span={isMobile ? 10 : 4}>
               <Title level={5}>
                 {t("hardware.label.field.checkin_counter")}
               </Title>
             </Col>
-            <Col span={18}>
+            <Col span={14}>
               <Text>{detail && detail?.checkin_counter}</Text>
             </Col>
           </Row>
           <Row gutter={16}>
-            <Col className="gutter-row" span={4}>
+            <Col className="gutter-row" span={isMobile ? 10 : 4}>
               <Title level={5}>
                 {t("hardware.label.field.checkout_counter")}
               </Title>
             </Col>
-            <Col span={18}>
+            <Col span={14}>
               <Text>{detail && detail?.checkout_counter}</Text>
             </Col>
           </Row>
           <Row gutter={16}>
-            <Col className="gutter-row" span={4}>
+            <Col className="gutter-row" span={isMobile ? 10 : 4}>
               <Title level={5}>{t("hardware.label.field.requestable")}</Title>
             </Col>
-            <Col span={18}>
+            <Col span={14}>
               <Text>{detail && detail?.requests_counter}</Text>
             </Col>
           </Row>
           <Row gutter={16}>
-            <Col className="gutter-row" span={4}>
+            <Col className="gutter-row" span={isMobile ? 10 : 4}>
               <Title level={5}>{t("hardware.label.field.purchase_cost")}</Title>
             </Col>
-            <Col span={18}>
+            <Col span={14}>
               <Text>{detail?.purchase_cost && detail?.purchase_cost}</Text>
             </Col>
           </Row>

--- a/src/pages/tax_token/show.tsx
+++ b/src/pages/tax_token/show.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from "@pankod/refine-core";
-import { Typography, Row, Col, Tag } from "@pankod/refine-antd";
+import { Typography, Row, Col, Tag, Grid } from "@pankod/refine-antd";
 import "styles/hardware.less";
 import { UserOutlined } from "@ant-design/icons";
 import { ITaxTokenResponse } from "interfaces/tax_token";
@@ -16,14 +16,16 @@ type TaxTokenShowProps = {
 export const TaxTokenShow = (props: TaxTokenShowProps) => {
   const { detail } = props;
   const t = useTranslate();
+  const breakpoint = Grid.useBreakpoint();
+  const isMobile = !breakpoint.lg;
 
   return (
     <>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tax_token.label.field.status")}</Title>
         </Col>
-        <Col>
+        <Col span={14}>
           <Text>
             <Tag>{getDetailTaxTokenStatus(detail)}</Tag>
             {detail?.assigned_to ? (
@@ -40,26 +42,26 @@ export const TaxTokenShow = (props: TaxTokenShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tax_token.label.field.name")}</Title>
         </Col>
-        <Col>
+        <Col span={14}>
           <Text>{detail && detail?.name}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tax_token.label.field.seri")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail && detail?.seri}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tax_token.label.field.supplier")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.supplier ? (
             <>
               <div
@@ -75,10 +77,10 @@ export const TaxTokenShow = (props: TaxTokenShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tax_token.label.field.location")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.location ? (
             <>
               <div
@@ -94,10 +96,10 @@ export const TaxTokenShow = (props: TaxTokenShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tax_token.label.field.category")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.category ? (
             <>
               <div
@@ -113,30 +115,30 @@ export const TaxTokenShow = (props: TaxTokenShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tax_token.label.field.purchase_date")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>
             {detail?.purchase_date && detail?.purchase_date.formatted}
           </Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tax_token.label.field.expiration_date")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>
             {detail?.purchase_date && detail?.expiration_date.formatted}
           </Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tax_token.label.field.note")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <div
             dangerouslySetInnerHTML={{
               __html: `<span>${detail?.note ? detail?.note : ""}</span>`,
@@ -145,10 +147,10 @@ export const TaxTokenShow = (props: TaxTokenShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tax_token.label.title.dateCreate")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.created_at ? (
             <Text>
               {" "}
@@ -163,10 +165,10 @@ export const TaxTokenShow = (props: TaxTokenShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tax_token.label.title.updateAt")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>
             {" "}
             {detail?.updated_at &&
@@ -177,10 +179,10 @@ export const TaxTokenShow = (props: TaxTokenShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tax_token.label.field.checkout_at")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.last_checkout ? (
             <>
               <Text>
@@ -193,44 +195,44 @@ export const TaxTokenShow = (props: TaxTokenShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tax_token.label.field.checkin_counter")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail && detail?.checkin_counter}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tax_token.label.field.checkout_counter")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail && detail?.checkout_counter}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tax_token.label.field.warranty_months")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>
             {detail?.warranty_months} ({t("tax_token.label.field.month")})
           </Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tax_token.label.field.qty")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail && detail?.qty}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tax_token.label.field.purchase_cost")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail?.purchase_cost && detail?.purchase_cost}</Text>
         </Col>
       </Row>

--- a/src/pages/tools/show.tsx
+++ b/src/pages/tools/show.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from "@pankod/refine-core";
-import { Typography, Tag, Row, Col } from "@pankod/refine-antd";
+import { Typography, Tag, Row, Col, Grid } from "@pankod/refine-antd";
 import "styles/hardware.less";
 import { UserOutlined } from "@ant-design/icons";
 import { IToolResponse } from "interfaces/tool";
@@ -15,13 +15,15 @@ type ToolShowProps = {
 export const ToolShow = (props: ToolShowProps) => {
   const { detail } = props;
   const t = useTranslate();
+  const breakpoint = Grid.useBreakpoint();
+  const isMobile = !breakpoint.lg;
   return (
     <>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tools.label.field.status")}</Title>
         </Col>
-        <Col>
+        <Col span={14}>
           <Text>
             <Tag>{getDetailToolStatus(detail)}</Tag>
             {detail?.assigned_to ? (
@@ -38,18 +40,18 @@ export const ToolShow = (props: ToolShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tools.label.field.name")}</Title>
         </Col>
-        <Col>
+        <Col span={14}>
           <Text>{detail && detail?.name}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tools.label.field.supplier")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.supplier ? (
             <>
               <div
@@ -65,10 +67,10 @@ export const ToolShow = (props: ToolShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tools.label.field.location")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.location ? (
             <>
               <div
@@ -84,10 +86,10 @@ export const ToolShow = (props: ToolShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tools.label.field.category")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.category ? (
             <>
               <div
@@ -103,30 +105,30 @@ export const ToolShow = (props: ToolShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tools.label.field.purchase_date")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>
             {detail?.purchase_date && detail?.purchase_date.formatted}
           </Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tools.label.field.expiration_date")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>
             {detail?.purchase_date && detail?.expiration_date.formatted}
           </Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tools.label.field.notes")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <div
             dangerouslySetInnerHTML={{
               __html: `<span>${detail?.notes ? detail?.notes : ""}</span>`,
@@ -135,10 +137,10 @@ export const ToolShow = (props: ToolShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tools.label.title.dateCreate")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.created_at ? (
             <Text>
               {" "}
@@ -153,10 +155,10 @@ export const ToolShow = (props: ToolShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tools.label.title.updateAt")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>
             {" "}
             {detail?.updated_at &&
@@ -167,10 +169,10 @@ export const ToolShow = (props: ToolShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tools.label.field.checkout_at")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           {detail?.last_checkout ? (
             <>
               <Text>
@@ -183,34 +185,34 @@ export const ToolShow = (props: ToolShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tools.label.field.checkin_counter")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail && detail?.checkin_counter}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tools.label.field.checkout_counter")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail && detail?.checkout_counter}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tools.label.field.qty")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail && detail?.qty}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("tools.label.field.purchase_cost")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail?.purchase_cost && detail?.purchase_cost}</Text>
         </Col>
       </Row>

--- a/src/pages/users/show-licenses.tsx
+++ b/src/pages/users/show-licenses.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from "@pankod/refine-core";
-import { Typography, Row, Col } from "@pankod/refine-antd";
+import { Typography, Row, Col, Grid } from "@pankod/refine-antd";
 import "styles/hardware.less";
 import { ILicensesResponse } from "interfaces/license";
 const { Title, Text } = Typography;
@@ -13,78 +13,79 @@ type LicensesUserShowProps = {
 export const LicensesUserShow = (props: LicensesUserShowProps) => {
   const { detail } = props;
   const t = useTranslate();
-
+  const breakpoint = Grid.useBreakpoint();
+  const isMobile = !breakpoint.lg;
   return (
     <>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("licenses.label.field.licenses")}</Title>
         </Col>
-        <Col>
+        <Col span={14}>
           <Text>{detail && detail?.licenses}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("licenses.label.field.software")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text className="show-asset">{detail && detail?.software.name}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("licenses.label.field.seats")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text> {detail && detail?.seats} </Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("licenses.label.field.checkout-count")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail && detail?.checkout_count}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("licenses.label.field.purchase_date")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail && detail?.purchase_date.formatted}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("licenses.label.field.expiration_date")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail && detail?.expiration_date.formatted}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("licenses.label.field.purchase_cost")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail && detail?.purchase_cost}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("licenses.label.field.created_at")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail && detail?.created_at.formatted}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("licenses.label.field.updated_at")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={14}>
           <Text>{detail && detail?.updated_at.formatted}</Text>
         </Col>
       </Row>

--- a/src/pages/users/show.tsx
+++ b/src/pages/users/show.tsx
@@ -1,8 +1,8 @@
 import { useTranslate } from "@pankod/refine-core";
-import { Typography, Tag } from "@pankod/refine-antd";
+import { Typography, Tag, Row, Col, Grid } from "@pankod/refine-antd";
 import { IHardwareResponse } from "interfaces/hardware";
 import { getDetailAssetStatus } from "untils/assets";
-import React from "react";
+import { UserOutlined } from "@ant-design/icons";
 
 const { Title, Text } = Typography;
 
@@ -14,31 +14,82 @@ type UserShowProps = {
 export const UserShow = (props: UserShowProps) => {
   const { detail } = props;
   const t = useTranslate();
-
+  const breakpoint = Grid.useBreakpoint();
+  const isMobile = !breakpoint.lg;
   return (
     <>
-      <Title level={5}>{t("user.label.field.name")}</Title>
-      <Text>{detail?.name}</Text>
-      <Title level={5}>{t("user.label.field.model")}</Title>
-      <Text>{detail?.model?.name}</Text>
-      <Title level={5}>{t("user.label.field.category")}</Title>
-      <Text>{detail?.category?.name}</Text>
-      <Title level={5}>{t("user.label.field.status")}</Title>
-      <Text>
-        <Tag>{getDetailAssetStatus(detail)}</Tag>
-      </Text>
-      <Title level={5}>{t("user.label.field.location")}</Title>
-      <Text>{detail?.rtd_location?.name}</Text>
-      <Title level={5}>{t("user.label.field.insurance")}</Title>
-      <Text>{detail?.warranty_months}</Text>
-      <Title level={5}>{t("user.label.field.notes")}</Title>
-      <Text>
-        {React.createElement("div", {
-          dangerouslySetInnerHTML: {
-            __html: `<span>${detail?.notes ? detail?.notes : ""}</span>`,
-          },
-        })}
-      </Text>
+      <Row gutter={16}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
+          <Title level={5}>{t("user.label.field.name")}</Title>
+        </Col>
+        <Col span={14}>
+          <Text>{detail && detail?.name}</Text>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
+          <Title level={5}>{t("user.label.field.model")}</Title>
+        </Col>
+        <Col span={14}>
+          <Text>{detail && detail?.model?.name}</Text>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
+          <Title level={5}>{t("user.label.field.category")}</Title>
+        </Col>
+        <Col span={14}>
+          <Text>{detail && detail?.category?.name}</Text>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
+          <Title level={5}>{t("user.label.field.status")}</Title>
+        </Col>
+        <Col span={14}>
+          <Text>
+            <Tag>{getDetailAssetStatus(detail)}</Tag>
+            {detail?.assigned_to ? (
+              <>
+                <UserOutlined />{" "}
+                <span className="show-asset">
+                  {detail?.assigned_to ? detail?.assigned_to.name : ""}
+                </span>
+              </>
+            ) : (
+              ""
+            )}
+          </Text>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
+          <Title level={5}>{t("user.label.field.location")}</Title>
+        </Col>
+        <Col span={14}>
+          <Text>{detail && detail?.rtd_location?.name}</Text>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
+          <Title level={5}>{t("user.label.field.insurance")}</Title>
+        </Col>
+        <Col span={14}>
+          <Text>{detail && detail?.warranty_months}</Text>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
+          <Title level={5}>{t("user.label.field.notes")}</Title>
+        </Col>
+        <Col span={14}>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: `<span>${detail?.notes ? detail?.notes : ""}</span>`,
+            }}
+          />
+        </Col>
+      </Row>
     </>
   );
 };

--- a/src/pages/webhook/show.tsx
+++ b/src/pages/webhook/show.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from "@pankod/refine-core";
-import { Typography, Row, Col } from "@pankod/refine-antd";
+import { Typography, Row, Col, Grid } from "@pankod/refine-antd";
 import "styles/hardware.less";
 import moment from "moment";
 import { IWebhookResponse } from "interfaces/webhook";
@@ -14,29 +14,31 @@ type HardwareShowProps = {
 export const WebhookShow = (props: HardwareShowProps) => {
   const { detail } = props;
   const t = useTranslate();
+  const breakpoint = Grid.useBreakpoint();
+  const isMobile = !breakpoint.lg;
   return (
     <>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("webhook.label.field.name")}</Title>
         </Col>
-        <Col>
+        <Col span={isMobile ? 14 : 20}>
           <Text>{detail && detail?.name}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("webhook.label.field.url")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={isMobile ? 14 : 20}>
           <Text>{detail && detail?.url}</Text>
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("webhook.label.field.created_at")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={isMobile ? 14 : 20}>
           {detail?.created_at ? (
             <Text>
               {" "}
@@ -51,10 +53,10 @@ export const WebhookShow = (props: HardwareShowProps) => {
         </Col>
       </Row>
       <Row gutter={16}>
-        <Col className="gutter-row" span={4}>
+        <Col className="gutter-row" span={isMobile ? 10 : 4}>
           <Title level={5}>{t("webhook.label.field.type")}</Title>
         </Col>
-        <Col span={18}>
+        <Col span={isMobile ? 14 : 20}>
           {detail?.type && detail?.type.length > 0 ? (
             detail?.type.map((item: string, index: number) => (
               <Text key={index}>


### PR DESCRIPTION
### Checklist (check all applicable)
- [x]  Self Review
- [x]  Self Test
- [x]  Upload Evidence
- [x]  Optimization
### Description
- Check popup detail in all table row
- Show full title in mobile
### Related Issues
- #93 
### Evidence
- Check popup detail in all table row
![AMS-NCCPLUS-06-25-2025_02_41_PM](https://github.com/user-attachments/assets/9e1d386f-d76a-49fd-9cd7-91e7cbbb56da)

- Show full title in mobile 
<img width="347" alt="Ảnh màn hình 2025-06-25 lúc 15 26 44" src="https://github.com/user-attachments/assets/9be1caf9-1ed5-40ad-ba3a-198cfea852eb" />
