### PR TITLE
Feat/192: Error Boundary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "react-cookie": "^4.1.1",
         "react-css-theme-switcher": "^0.3.0",
         "react-dom": "^17.0.2",
+        "react-error-boundary": "^6.0.0",
         "react-google-login": "^5.2.2",
         "react-i18next": "^15.6.1",
         "react-icons": "^4.10.1",
@@ -28417,6 +28418,18 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.0.0.tgz",
+      "integrity": "sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-error-overlay": {
       "version": "6.0.10",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
@@ -55851,6 +55864,14 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.2"
+      }
+    },
+    "react-error-boundary": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.0.0.tgz",
+      "integrity": "sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-cookie": "^4.1.1",
     "react-css-theme-switcher": "^0.3.0",
     "react-dom": "^17.0.2",
+    "react-error-boundary": "^6.0.0",
     "react-google-login": "^5.2.2",
     "react-i18next": "^15.6.1",
     "react-icons": "^4.10.1",

--- a/public/images/svg/error-icon.svg
+++ b/public/images/svg/error-icon.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="120"
+  height="120"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ff4d4f"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+  <line x1="12" y1="9" x2="12" y2="13" />
+  <line x1="12" y1="17" x2="12" y2="17" />
+</svg>

--- a/src/components/Fallback/ContentFallback/index.tsx
+++ b/src/components/Fallback/ContentFallback/index.tsx
@@ -1,0 +1,21 @@
+import { FallbackProps } from "react-error-boundary";
+import "./style.less";
+
+export const Fallback = ({ resetErrorBoundary }: FallbackProps) => {
+  return (
+    <div className="fallback-container">
+      <div className="fallback-icon">
+        <img
+          width={100}
+          style={{ marginRight: 10 }}
+          src="/images/svg/error-icon.svg"
+        />
+      </div>
+      <h2 className="fallback-title">OOPS!</h2>
+      <p className="fallback-subtitle">Something went wrong.Please try again</p>
+      <button className="fallback-button" onClick={resetErrorBoundary}>
+        Retry
+      </button>
+    </div>
+  );
+};

--- a/src/components/Fallback/ContentFallback/style.less
+++ b/src/components/Fallback/ContentFallback/style.less
@@ -1,0 +1,52 @@
+@import "styles/antd.less";
+
+.fallback-container {
+  min-height: 100vh;              
+  display: flex;
+  flex-direction: column;
+  justify-content: center;        
+  align-items: center;            
+  text-align: center;
+  padding: 24px;
+  background: #fff;               
+}
+
+.fallback-icon {
+  margin-bottom: 20px;
+}
+
+.fallback-title {
+  font-size: 32px;
+  font-weight: 700;
+  margin-bottom: 12px;
+  color: @primary-color;
+  letter-spacing: 1px;
+}
+
+.fallback-subtitle {
+  font-size: 16px;
+  color: @text-color;
+  margin-bottom: 28px;
+}
+
+.fallback-button {
+  background: @primary-color;
+  color: white;
+  padding: 12px 28px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 16px;
+  transition: all 0.25s ease;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+
+  &:hover {
+    background: darken(@primary-color, 8%);
+    box-shadow: 0 4px 10px rgba(0,0,0,0.2);
+  }
+
+  &:active {
+    transform: scale(0.96);
+  }
+}

--- a/src/components/Fallback/HeaderFallback/index.tsx
+++ b/src/components/Fallback/HeaderFallback/index.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { FallbackProps } from "react-error-boundary";
+import { Button } from "antd";
+import { useLogout, useNavigation } from "@pankod/refine-core";
+import { LocalStorageKey } from "enums/LocalStorageKey";
+import { AntdLayout, Icons } from "@pankod/refine-antd";
+const { LogoutOutlined } = Icons;
+
+const style: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "flex-end",
+  alignItems: "center",
+  padding: "0px 24px",
+  height: "64px",
+  backgroundColor: "#FFF",
+};
+
+export const HeaderFallback: React.FC<FallbackProps> = () => {
+  const { mutate: logout } = useLogout();
+  const { push } = useNavigation();
+  const logoutAccount = () => {
+    logout();
+    localStorage.removeItem(LocalStorageKey.UNAUTHORIZED);
+    push("/login");
+  };
+
+  return (
+    <div>
+      <AntdLayout.Header style={style}>
+        <Button
+          type="link"
+          onClick={() => {
+            logoutAccount();
+          }}
+          data-test-id="logout-btn"
+        >
+          <LogoutOutlined />
+        </Button>
+      </AntdLayout.Header>
+    </div>
+  );
+};
+
+export default HeaderFallback;

--- a/src/components/layout/layout/index.tsx
+++ b/src/components/layout/layout/index.tsx
@@ -1,9 +1,13 @@
 import { AntdLayout, Grid } from "@pankod/refine-antd";
 import { LayoutProps } from "@pankod/refine-core";
-import { FC, PropsWithChildren, useEffect, useState } from "react";
+import { FC, PropsWithChildren, useEffect, useState, useMemo } from "react";
 import { UnauthorizedModal } from "components/Modal/UnauthorizedModal";
 import { EBooleanString } from "constants/common";
 import { LocalStorageKey } from "enums/LocalStorageKey";
+import { ErrorBoundary } from "react-error-boundary";
+import { Fallback } from "components/Fallback/ContentFallback";
+import { useLocation } from "react-router-dom";
+import HeaderFallback from "components/Fallback/HeaderFallback";
 
 export const Layout: FC<PropsWithChildren<LayoutProps>> = ({
   children,
@@ -36,11 +40,37 @@ export const Layout: FC<PropsWithChildren<LayoutProps>> = ({
     };
   }, []);
 
+  const ContentWithBoundary: FC<PropsWithChildren<any>> = ({ children }) => {
+    const location = useLocation();
+    return (
+      <ErrorBoundary
+        FallbackComponent={Fallback}
+        resetKeys={[location.pathname, location.search]}
+        onReset={() => {
+          window.location.reload();
+        }}
+      >
+        {children}
+      </ErrorBoundary>
+    );
+  };
+
+  const SiderNode = useMemo(() => (Sider ? <Sider /> : null), [Sider]);
+  const HeaderNode = useMemo(
+    () =>
+      Header ? (
+        <ErrorBoundary FallbackComponent={HeaderFallback}>
+          <Header />
+        </ErrorBoundary>
+      ) : null,
+    [Header]
+  );
+
   return (
     <AntdLayout style={{ minHeight: "100vh", flexDirection: "row" }}>
-      {Sider && <Sider />}
+      {SiderNode}
       <AntdLayout>
-        {Header && <Header />}
+        {HeaderNode}
         <AntdLayout.Content>
           <div
             style={{
@@ -48,7 +78,7 @@ export const Layout: FC<PropsWithChildren<LayoutProps>> = ({
               minHeight: 360,
             }}
           >
-            {children}
+            <ContentWithBoundary>{children}</ContentWithBoundary>
           </div>
           {OffLayoutArea && <OffLayoutArea />}
         </AntdLayout.Content>


### PR DESCRIPTION
# Checklist (check all applicable) (*)
- [x] Self Review
- [x] Self Test
- [x] Upload Evidence
- [x] Optimization

# Description
- Install react-error-boundary
- Add error boundary for app (cover content, header crash)

# Related Tickets & Documents (*)
- Related Issue #192 

# Evidence (*)
## [15/09/2025]  

### Screen when content crash 
<img width="1350" height="606" alt="image" src="https://github.com/user-attachments/assets/901abdab-d31d-4191-bb4d-501d01603183" />

### Screen when header crash 
<img width="1353" height="614" alt="image" src="https://github.com/user-attachments/assets/5f9378c2-a9da-448b-b52e-de3b30e0d570" />